### PR TITLE
Adds setup.py and a MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include sdclientapi/*.py
+include README.md
+include LICENSE
+include setup.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="sdclientapi",
+    version="0.1.0",
+    author="Kushal Das",
+    author_email="kushal@freedom.press",
+    description="Python client API to access SecureDrop Journalist REST API",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    install_requires=["requests", "mypy-extensions"],
+    python_requires='>=3.5',
+    url="https://github.com/freedomofpress/sdclientapi",
+    packages=setuptools.find_packages(exclude=['docs', 'tests']),
+    classifiers=(
+        "Development Status :: 3 - Alpha",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        'Intended Audience :: Developers',
+        "Operating System :: OS Independent",
+    ),
+)


### PR DESCRIPTION
Now we can create sdists for pypi.org.

Fixes part of #3.

### How to test?

```
python setup.py sdist
```

The above command should create a source tarball.